### PR TITLE
fix: startActivityForResult instead of startActivity + logs + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Trigger the Google Play Inline Install overlay from a Capacitor app.
 
-Note: Inline Install is only available to certain apps that qualify for Premium Growth Tools. See eligibility and program details here: https://play.google.com/console/about/guides/premium-growth-tools/
+Note: Inline Install is [only available to certain apps that qualify for Premium Growth Tools](https://developer.android.com/quality/core-value/app-eligibility). See eligibility and program details here: https://play.google.com/console/about/guides/premium-growth-tools/
 
 ## Why Android Inline Install?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 
 Trigger the Google Play Inline Install overlay from a Capacitor app.
 
-Note: Inline Install is [only available to certain apps that qualify for Premium Growth Tools](https://developer.android.com/quality/core-value/app-eligibility). See eligibility and program details here: https://play.google.com/console/about/guides/premium-growth-tools/
+> [!NOTE]
+> Inline Install is [only available to certain apps that qualify for Premium Growth Tools](https://developer.android.com/quality/core-value/app-eligibility). See eligibility and program details here: https://play.google.com/console/about/guides/premium-growth-tools/
+
+> [!CAUTION] 
+> When using an app id that is published on the Play Store, but might not necessarily be eligible for Premium Growth Tools, the fallback will be used. (No overlay will be shown.)
 
 ## Why Android Inline Install?
 

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -30,7 +30,7 @@ public class AndroidInlineInstallPlugin extends Plugin {
         String callerId = call.getString("callerId", getContext().getPackageName());
         String cslId = call.getString("csl_id");
         boolean overlay = call.getBoolean("overlay", true);
-        boolean fallback = false;
+        boolean fallback = call.getBoolean("fallback", true);
 
         // Format:
         // https://play.google.com/d?id=<id>&referrer=<referrer>&listing=<csl_id>

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -52,7 +52,7 @@ public class AndroidInlineInstallPlugin extends Plugin {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setPackage("com.android.vending");
         intent.setData(Uri.parse(deepLinkUrl));
-        intent.putExtra("overlay", true);
+        intent.putExtra("overlay", overlay);
         intent.putExtra("callerId", callerId);
 
         PackageManager packageManager = getContext().getPackageManager();

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -36,7 +36,6 @@ public class AndroidInlineInstallPlugin extends Plugin {
         // https://play.google.com/d?id=<id>&referrer=<referrer>&listing=<csl_id>
         StringBuilder deepLink = new StringBuilder("https://play.google.com/d?id=")
                 .append(id);
-        // Temporarily commenting out referrer to test if it's causing the issue
 
         if (referrer != null && !referrer.trim().isEmpty()) {
             deepLink.append("&referrer=").append(Uri.encode(referrer));

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -1,9 +1,11 @@
 package app.capgo.android.inline.install;
 
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -13,6 +15,7 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "AndroidInlineInstall")
 public class AndroidInlineInstallPlugin extends Plugin {
 
+    private static final String TAG = "AndroidInlineInstallPlugin";
     private final String pluginVersion = "7.5.11";
 
     @PluginMethod
@@ -23,39 +26,57 @@ public class AndroidInlineInstallPlugin extends Plugin {
             return;
         }
 
-        String referrer = call.getString("referrer", "");
+        String referrer = "utm_source=heycash&utm_medium=inline";
         String callerId = call.getString("callerId", getContext().getPackageName());
         String cslId = call.getString("csl_id");
         boolean overlay = call.getBoolean("overlay", true);
-        boolean fallback = call.getBoolean("fallback", true);
+        boolean fallback = false;
 
         // Build the deep link URL for inline install overlay
+        // Format:
+        // https://play.google.com/d?id=<id>&referrer=<referrer>&listing=<csl_id>
+        // Note: Trying without referrer first, as it might be causing the PITH error
         StringBuilder deepLink = new StringBuilder("https://play.google.com/d?id=")
-            .append(id)
-            .append("&referrer=")
-            .append(Uri.encode(referrer == null ? "" : referrer));
+                .append(id);
+        // Temporarily commenting out referrer to test if it's causing the issue
+
+        if (referrer != null && !referrer.trim().isEmpty()) {
+            deepLink.append("&referrer=").append(Uri.encode(referrer));
+        }
         if (cslId != null && !cslId.trim().isEmpty()) {
             deepLink.append("&listing=").append(Uri.encode(cslId));
         }
 
+        String deepLinkUrl = deepLink.toString();
+        Log.d(TAG, "Attempting inline install with URI: " + deepLinkUrl);
+        Log.d(TAG, "callerId: " + callerId + ", overlay: " + overlay);
+        Log.d(TAG, "referrer: " + referrer);
+
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setPackage("com.android.vending");
-        intent.setData(Uri.parse(deepLink.toString()));
-        intent.putExtra("overlay", overlay);
+        intent.setData(Uri.parse(deepLinkUrl));
+        intent.putExtra("overlay", true);
         intent.putExtra("callerId", callerId);
 
         PackageManager packageManager = getContext().getPackageManager();
-        if (intent.resolveActivity(packageManager) != null) {
+        ComponentName resolvedActivity = intent.resolveActivity(packageManager);
+        Log.d(TAG, "resolveActivity returned: " + (resolvedActivity != null ? resolvedActivity.toString() : "null"));
+        if (resolvedActivity != null) {
+            Log.d(TAG, "Activity resolved, attempting to start inline install");
             try {
-                getActivity().startActivity(intent);
+                getActivity().startActivityForResult(intent, 0);
+                Log.d(TAG, "Inline install activity started successfully");
                 JSObject ret = new JSObject();
                 ret.put("started", true);
                 ret.put("fallbackUsed", false);
                 call.resolve(ret);
                 return;
             } catch (ActivityNotFoundException ex) {
+                Log.w(TAG, "ActivityNotFoundException when starting inline install", ex);
                 // fall through to fallback handling
             }
+        } else {
+            Log.w(TAG, "No activity resolved for inline install intent, will use fallback");
         }
 
         if (fallback) {
@@ -64,15 +85,19 @@ public class AndroidInlineInstallPlugin extends Plugin {
             if (referrer != null && !referrer.isEmpty()) {
                 storeUrl.append("&referrer=").append(Uri.encode(referrer));
             }
-            Intent fallbackIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(storeUrl.toString()));
+            String fallbackUrl = storeUrl.toString();
+            Log.d(TAG, "Falling back to Play Store URL: " + fallbackUrl);
+            Intent fallbackIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(fallbackUrl));
             try {
-                getActivity().startActivity(fallbackIntent);
+                getActivity().startActivityForResult(fallbackIntent, 0  );
+                Log.d(TAG, "Fallback Play Store activity started successfully");
                 JSObject ret = new JSObject();
                 ret.put("started", true);
                 ret.put("fallbackUsed", true);
                 call.resolve(ret);
                 return;
             } catch (ActivityNotFoundException ex) {
+                Log.e(TAG, "ActivityNotFoundException when starting fallback Play Store", ex);
                 call.reject("Unable to start inline install or fallback Play Store deep link");
                 return;
             }

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -26,7 +26,7 @@ public class AndroidInlineInstallPlugin extends Plugin {
             return;
         }
 
-        String referrer = "utm_source=heycash&utm_medium=inline";
+        String referrer = call.getString("referrer", "");
         String callerId = call.getString("callerId", getContext().getPackageName());
         String cslId = call.getString("csl_id");
         boolean overlay = call.getBoolean("overlay", true);
@@ -89,7 +89,7 @@ public class AndroidInlineInstallPlugin extends Plugin {
             Log.d(TAG, "Falling back to Play Store URL: " + fallbackUrl);
             Intent fallbackIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(fallbackUrl));
             try {
-                getActivity().startActivityForResult(fallbackIntent, 0  );
+                getActivity().startActivityForResult(fallbackIntent, 0);
                 Log.d(TAG, "Fallback Play Store activity started successfully");
                 JSObject ret = new JSObject();
                 ret.put("started", true);

--- a/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
+++ b/android/src/main/java/app/capgo/android/inline/insall/AndroidInlineInstallPlugin.java
@@ -32,10 +32,8 @@ public class AndroidInlineInstallPlugin extends Plugin {
         boolean overlay = call.getBoolean("overlay", true);
         boolean fallback = false;
 
-        // Build the deep link URL for inline install overlay
         // Format:
         // https://play.google.com/d?id=<id>&referrer=<referrer>&listing=<csl_id>
-        // Note: Trying without referrer first, as it might be causing the PITH error
         StringBuilder deepLink = new StringBuilder("https://play.google.com/d?id=")
                 .append(id);
         // Temporarily commenting out referrer to test if it's causing the issue


### PR DESCRIPTION
### Motivation

One of our enterprise clients using this plugin found out that `startActivityForResult(intent, 0)` must be used for the overlay to open. After having confirmed this, I am introducing this change.

Furthermore, this PR introduces important docs in the README that explain the limitations of this plugin/inline overlay on Android.

This PR is to be backported to V7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline install flow with more robust activity resolution, explicit fallback handling, and clearer failure behavior.
  * Refined referrer/listing parameter handling to reliably preserve install context.

* **Chores**
  * Added extensive runtime logging to aid troubleshooting of install and fallback paths.

* **Documentation**
  * Clarified eligibility and fallback behavior in README with highlighted NOTE and CAUTION guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->